### PR TITLE
[DEV-57] 컨트롤러 이하에서 발생하는 예외들을 잡아서 합의된 형태의 json으로 변환하여 사용자에게 반환하는 전역 예외 핸들러 작성

### DIFF
--- a/src/main/java/com/tiketeer/Tiketeer/domain/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/member/exception/MemberNotFoundException.java
@@ -1,0 +1,10 @@
+package com.tiketeer.Tiketeer.domain.member.exception;
+
+import com.tiketeer.Tiketeer.exception.DefinedException;
+import com.tiketeer.Tiketeer.exception.code.MemberExceptionCode;
+
+public class MemberNotFoundException extends DefinedException {
+	public MemberNotFoundException() {
+		super(MemberExceptionCode.MEMBER_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/tiketeer/Tiketeer/domain/ticket/exception/TicketNotFoundException.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/ticket/exception/TicketNotFoundException.java
@@ -1,0 +1,10 @@
+package com.tiketeer.Tiketeer.domain.ticket.exception;
+
+import com.tiketeer.Tiketeer.exception.DefinedException;
+import com.tiketeer.Tiketeer.exception.code.TicketExceptionCode;
+
+public class TicketNotFoundException extends DefinedException {
+	public TicketNotFoundException() {
+		super(TicketExceptionCode.TICKET_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/tiketeer/Tiketeer/domain/ticketing/exception/TicketingNotFoundException.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/ticketing/exception/TicketingNotFoundException.java
@@ -1,0 +1,10 @@
+package com.tiketeer.Tiketeer.domain.ticketing.exception;
+
+import com.tiketeer.Tiketeer.exception.DefinedException;
+import com.tiketeer.Tiketeer.exception.code.TicketingExceptionCode;
+
+public class TicketingNotFoundException extends DefinedException {
+	public TicketingNotFoundException() {
+		super(TicketingExceptionCode.TICKETING_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/tiketeer/Tiketeer/exception/DefinedException.java
+++ b/src/main/java/com/tiketeer/Tiketeer/exception/DefinedException.java
@@ -1,0 +1,19 @@
+package com.tiketeer.Tiketeer.exception;
+
+import com.tiketeer.Tiketeer.exception.code.ExceptionCode;
+
+import lombok.Getter;
+
+@Getter
+public class DefinedException extends RuntimeException {
+	private final ExceptionCode exceptionCode;
+
+	protected DefinedException(ExceptionCode exceptionCode) {
+		this.exceptionCode = exceptionCode;
+	}
+
+	protected DefinedException(ExceptionCode exceptionCode, String message) {
+		super(message);
+		this.exceptionCode = exceptionCode;
+	}
+}

--- a/src/main/java/com/tiketeer/Tiketeer/exception/ErrorResponse.java
+++ b/src/main/java/com/tiketeer/Tiketeer/exception/ErrorResponse.java
@@ -1,0 +1,18 @@
+package com.tiketeer.Tiketeer.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class ErrorResponse {
+	private String code;
+	private String message;
+
+	@Builder
+	public ErrorResponse(String code, String message) {
+		this.code = code;
+		this.message = message;
+	}
+}

--- a/src/main/java/com/tiketeer/Tiketeer/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tiketeer/Tiketeer/exception/GlobalExceptionHandler.java
@@ -1,0 +1,38 @@
+package com.tiketeer.Tiketeer.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import com.tiketeer.Tiketeer.exception.code.CommonExceptionCode;
+import com.tiketeer.Tiketeer.exception.code.ExceptionCode;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+	@ExceptionHandler({})
+	protected ResponseEntity<ErrorResponse> handleDefinedException(final DefinedException e) {
+		logError(e);
+		return createErrorResponse(e.getExceptionCode());
+	}
+
+	@ExceptionHandler(Exception.class)
+	protected ResponseEntity<ErrorResponse> handleUndefinedException(final Exception e) {
+		logError(e);
+		return createErrorResponse(CommonExceptionCode.INTERNAL_SERVER_ERROR);
+	}
+
+	private ResponseEntity<ErrorResponse> createErrorResponse(ExceptionCode exceptionCode) {
+		return ResponseEntity.status(exceptionCode.getHttpStatus()).body(ErrorResponse.builder()
+			.code(exceptionCode.name())
+			.message(exceptionCode.getMessage())
+			.build());
+	}
+
+	private void logError(final Exception e) {
+		log.error(e.getClass().getName(), e);
+	}
+}

--- a/src/main/java/com/tiketeer/Tiketeer/exception/code/AuthExceptionCode.java
+++ b/src/main/java/com/tiketeer/Tiketeer/exception/code/AuthExceptionCode.java
@@ -1,0 +1,17 @@
+package com.tiketeer.Tiketeer.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthExceptionCode implements ExceptionCode {
+	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다. 재로그인이 필요합니다."),
+	WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "잘못된 패스워드입니다. 다시 시도해주십시오."),
+	INSUFFICIENT_PERMISSIONS(HttpStatus.FORBIDDEN, "작업을 수행할 권한이 부족합니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/com/tiketeer/Tiketeer/exception/code/CommonExceptionCode.java
+++ b/src/main/java/com/tiketeer/Tiketeer/exception/code/CommonExceptionCode.java
@@ -1,0 +1,16 @@
+package com.tiketeer.Tiketeer.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonExceptionCode implements ExceptionCode {
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 측에서 문제가 발생했습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}
+

--- a/src/main/java/com/tiketeer/Tiketeer/exception/code/ExceptionCode.java
+++ b/src/main/java/com/tiketeer/Tiketeer/exception/code/ExceptionCode.java
@@ -1,0 +1,11 @@
+package com.tiketeer.Tiketeer.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface ExceptionCode {
+	String name();
+
+	HttpStatus getHttpStatus();
+
+	String getMessage();
+}

--- a/src/main/java/com/tiketeer/Tiketeer/exception/code/MemberExceptionCode.java
+++ b/src/main/java/com/tiketeer/Tiketeer/exception/code/MemberExceptionCode.java
@@ -1,0 +1,16 @@
+package com.tiketeer.Tiketeer.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberExceptionCode implements ExceptionCode {
+	DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."), MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND,
+		"존재하지 않는 멤버입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/com/tiketeer/Tiketeer/exception/code/TicketExceptionCode.java
+++ b/src/main/java/com/tiketeer/Tiketeer/exception/code/TicketExceptionCode.java
@@ -1,0 +1,15 @@
+package com.tiketeer.Tiketeer.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TicketExceptionCode implements ExceptionCode {
+	TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 티켓입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/com/tiketeer/Tiketeer/exception/code/TicketingExceptionCode.java
+++ b/src/main/java/com/tiketeer/Tiketeer/exception/code/TicketingExceptionCode.java
@@ -1,0 +1,15 @@
+package com.tiketeer.Tiketeer.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TicketingExceptionCode implements ExceptionCode {
+	TICKETING_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 티케팅입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}


### PR DESCRIPTION
- 작업 내용
  - 예외 코드 인터페이스 정의 및 이를 구현하는 각 도메인 별 예외 코드 작성(API 문서 참조: https://tiketeer.notion.site/24e5b812feac4d1381fd28a04f7a488d)
  - 개발 단계에서 직접 정의하는 예외들이 상속해야 할 부모 클래스 작성 (DefinedException)
  - 컨트롤러 이하에서 발생하는 예외들을 전부 잡아서 사용자에게 사전에 정의한 형태로 내려주는 핸들러 작성
  - 더미 컨트롤러를 통한 전역 핸들러 테스트 코드 작성 (예정)