### PR TITLE
[DEV-90] JWT Auth filter 작성 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,3 @@
 
 - 서버 실행 후 스웨거를 통해 확인 가능
 - /swagger-ui/index.html
-- 접속 후 username: user, password: {서버 실행 시 반환되는 패스워드 문자열} 입력 (이는 아직 Security 엔드포인트 설정을 해주지 않아서 그런 것. 수정 후 해당 라인 삭제 요망)

--- a/src/main/java/com/tiketeer/Tiketeer/auth/FilterExceptionResolver.java
+++ b/src/main/java/com/tiketeer/Tiketeer/auth/FilterExceptionResolver.java
@@ -1,0 +1,9 @@
+package com.tiketeer.Tiketeer.auth;
+
+import java.io.IOException;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+public interface FilterExceptionResolver<T extends RuntimeException> {
+	public void setResponse(HttpServletResponse response, T ex) throws IOException;
+}

--- a/src/main/java/com/tiketeer/Tiketeer/auth/JwtFilterExceptionResolver.java
+++ b/src/main/java/com/tiketeer/Tiketeer/auth/JwtFilterExceptionResolver.java
@@ -11,9 +11,7 @@ import com.tiketeer.Tiketeer.exception.ErrorResponse;
 
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Component
 public class JwtFilterExceptionResolver implements FilterExceptionResolver<JwtException> {
 

--- a/src/main/java/com/tiketeer/Tiketeer/auth/JwtFilterExceptionResolver.java
+++ b/src/main/java/com/tiketeer/Tiketeer/auth/JwtFilterExceptionResolver.java
@@ -1,0 +1,31 @@
+package com.tiketeer.Tiketeer.auth;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tiketeer.Tiketeer.exception.ErrorResponse;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class JwtFilterExceptionResolver implements FilterExceptionResolver<JwtException> {
+
+	@Override
+	public void setResponse(HttpServletResponse response, JwtException ex) throws IOException {
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+		//only load general error stack to hide info
+		response.getWriter()
+			.write(new ObjectMapper().writeValueAsString(
+				new ErrorResponse(HttpStatus.UNAUTHORIZED.name(), ex.getMessage())));
+
+	}
+}

--- a/src/main/java/com/tiketeer/Tiketeer/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tiketeer/Tiketeer/auth/jwt/JwtAuthenticationFilter.java
@@ -42,17 +42,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			GrantedAuthority authority = new SimpleGrantedAuthority(role);
 			Authentication authentication = new UsernamePasswordAuthenticationToken(email, null, List.of(authority));
 			SecurityContextHolder.getContext().setAuthentication(authentication);
+			filterChain.doFilter(request, response);
 
 		} catch (JwtException ex) {
 			logger.info("Failed to authorize/authenticate with JWT due to " + ex.getMessage());
 			jwtFilterExceptionResolver.setResponse(response, ex);
 		}
 
-		filterChain.doFilter(request, response);
 	}
 
 	private String getAccessTokenFromCookie(HttpServletRequest request) {
 		Cookie[] cookies = request.getCookies();
+		if (cookies == null) {
+			throw new JwtException("Missing cookie");
+		}
+
 		for (Cookie cookie : cookies) {
 			if (cookie.getName().equals(JwtMetadata.ACCESS_TOKEN)) {
 				return cookie.getValue();

--- a/src/main/java/com/tiketeer/Tiketeer/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tiketeer/Tiketeer/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,63 @@
+package com.tiketeer.Tiketeer.auth.jwt;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.tiketeer.Tiketeer.auth.FilterExceptionResolver;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtService jwtService;
+	private final FilterExceptionResolver<JwtException> jwtFilterExceptionResolver;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		try {
+			final String accessToken = getAccessTokenFromCookie(request);
+			JwtPayload jwtPayload = jwtService.verifyToken(accessToken);
+			var email = jwtPayload.email();
+			var role = jwtPayload.roleEnum().name();
+			GrantedAuthority authority = new SimpleGrantedAuthority(role);
+			Authentication authentication = new UsernamePasswordAuthenticationToken(email, null, List.of(authority));
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		} catch (JwtException ex) {
+			logger.info("Failed to authorize/authenticate with JWT due to " + ex.getMessage());
+			jwtFilterExceptionResolver.setResponse(response, ex);
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private String getAccessTokenFromCookie(HttpServletRequest request) {
+		Cookie[] cookies = request.getCookies();
+		for (Cookie cookie : cookies) {
+			if (cookie.getName().equals(JwtMetadata.ACCESS_TOKEN)) {
+				return cookie.getValue();
+			}
+		}
+		throw new JwtException("Missing Token");
+	}
+}

--- a/src/main/java/com/tiketeer/Tiketeer/auth/jwt/JwtMetadata.java
+++ b/src/main/java/com/tiketeer/Tiketeer/auth/jwt/JwtMetadata.java
@@ -1,0 +1,6 @@
+package com.tiketeer.Tiketeer.auth.jwt;
+
+public class JwtMetadata {
+	static final String ACCESS_TOKEN = "accessToken";
+	static final String REFRESH_TOKEN = "refreshToken";
+}

--- a/src/main/java/com/tiketeer/Tiketeer/configuration/SecurityConfig.java
+++ b/src/main/java/com/tiketeer/Tiketeer/configuration/SecurityConfig.java
@@ -12,6 +12,9 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import com.tiketeer.Tiketeer.auth.jwt.JwtAuthenticationFilter;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,6 +22,8 @@ import lombok.RequiredArgsConstructor;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
 	@Bean
 	public PasswordEncoder passwordEncoder() {
@@ -31,9 +36,11 @@ public class SecurityConfig {
 		return http.csrf(AbstractHttpConfigurer::disable)
 			.formLogin(AbstractHttpConfigurer::disable)
 			.httpBasic(AbstractHttpConfigurer::disable)
+			.addFilterBefore(jwtAuthenticationFilter, BasicAuthenticationFilter.class)
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(req ->
 				req.requestMatchers(getPermitAllPaths()).permitAll()
+					
 					.anyRequest()
 					.authenticated()
 			)

--- a/src/test/java/com/tiketeer/Tiketeer/auth/JwtFilterExceptionResolverTest.java
+++ b/src/test/java/com/tiketeer/Tiketeer/auth/JwtFilterExceptionResolverTest.java
@@ -1,0 +1,50 @@
+package com.tiketeer.Tiketeer.auth;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tiketeer.Tiketeer.exception.ErrorResponse;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.http.HttpServletResponse;
+
+@SpringBootTest
+class JwtFilterExceptionResolverTest {
+
+	@Autowired
+	JwtFilterExceptionResolver jwtFilterExceptionResolver;
+
+	@Test
+	void setResponse() throws IOException {
+		HttpServletResponse response = mock(HttpServletResponse.class);
+		JwtException exception = new JwtException("invalid jwt");
+
+		StringWriter stringWriter = new StringWriter();
+		PrintWriter printWriter = new PrintWriter(stringWriter);
+		when(response.getWriter()).thenReturn(printWriter);
+
+		jwtFilterExceptionResolver.setResponse(response, exception);
+
+		verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		verify(response).setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+		String responseContent = stringWriter.toString();
+
+		String expectedJson = new ObjectMapper().writeValueAsString(
+			new ErrorResponse(HttpStatus.UNAUTHORIZED.name(), "invalid jwt")
+		);
+
+		assertThat(expectedJson).isEqualTo(responseContent);
+	}
+}

--- a/src/test/java/com/tiketeer/Tiketeer/auth/JwtFilterExceptionResolverTest.java
+++ b/src/test/java/com/tiketeer/Tiketeer/auth/JwtFilterExceptionResolverTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,6 +27,7 @@ class JwtFilterExceptionResolverTest {
 	JwtFilterExceptionResolver jwtFilterExceptionResolver;
 
 	@Test
+	@DisplayName("모킹된 ServletResponse > resolver 통과 > 일치여부 검사")
 	void setResponse() throws IOException {
 		HttpServletResponse response = mock(HttpServletResponse.class);
 		JwtException exception = new JwtException("invalid jwt");

--- a/src/test/java/com/tiketeer/Tiketeer/configuration/SecurityDisableForTestConfig.java
+++ b/src/test/java/com/tiketeer/Tiketeer/configuration/SecurityDisableForTestConfig.java
@@ -10,6 +10,8 @@ public class SecurityDisableForTestConfig {
 	@Bean
 	public SecurityFilterChain disableFilterChain(HttpSecurity http) throws Exception {
 		http.csrf(csrf -> csrf.disable()).httpBasic(c -> c.disable());
+
+		System.out.println("TTTTTTTTTTTTTTTTTTTTTTTTTTTT");
 		return http.build();
 	}
 }

--- a/src/test/java/com/tiketeer/Tiketeer/configuration/SecurityDisableForTestConfig.java
+++ b/src/test/java/com/tiketeer/Tiketeer/configuration/SecurityDisableForTestConfig.java
@@ -10,8 +10,6 @@ public class SecurityDisableForTestConfig {
 	@Bean
 	public SecurityFilterChain disableFilterChain(HttpSecurity http) throws Exception {
 		http.csrf(csrf -> csrf.disable()).httpBasic(c -> c.disable());
-
-		System.out.println("TTTTTTTTTTTTTTTTTTTTTTTTTTTT");
 		return http.build();
 	}
 }

--- a/src/test/java/com/tiketeer/Tiketeer/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/tiketeer/Tiketeer/exception/GlobalExceptionHandlerTest.java
@@ -23,7 +23,7 @@ import com.tiketeer.Tiketeer.exception.code.TicketingExceptionCode;
 
 @Import({SecurityDisableForTestConfig.class, DummyRestController.class})
 @SpringBootTest
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 public class GlobalExceptionHandlerTest {
 	private final MockMvc mockMvc;
 	private final ObjectMapper objectMapper;


### PR DESCRIPTION
### 고려 포인트
* JWT에서 예외가 발생했을 때 어떤 예외인지 명시된 정보를 응답값에 실어서 보내는게 보안적으로 좋지 않다고 생각해서 401 + General Message 만 보냄
  * 다만 내부적으로 로그는 찍음

* Filter에서 exception 발생 시 반환값을 제어해야 함
  * 반환값 제어를 필터 내부에서 하지 않고 별도 모듈로 분리
  * 제네릭을 사용하는게 조금 걸리긴 하는데.. 사용하지 않으면 런타임 체크를 할수밖에 없어서 그대로 작성