### PR TITLE
[DEV-84] refresh token 재발급 EP

### DIFF
--- a/src/main/java/com/tiketeer/Tiketeer/configuration/SecurityConfig.java
+++ b/src/main/java/com/tiketeer/Tiketeer/configuration/SecurityConfig.java
@@ -57,6 +57,6 @@ public class SecurityConfig {
 	}
 
 	private List<String> getMemberPaths() {
-		return List.of("/auth/login", "/members/register");
+		return List.of("/auth/login", "/members/register", "/auth/refresh");
 	}
 }

--- a/src/main/java/com/tiketeer/Tiketeer/domain/member/constant/CookieConfig.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/member/constant/CookieConfig.java
@@ -1,0 +1,8 @@
+package com.tiketeer.Tiketeer.domain.member.constant;
+
+public class CookieConfig {
+	public static final int MAX_AGE = 5 * 60;
+
+	private CookieConfig() {
+	}
+}

--- a/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/AuthController.java
@@ -23,6 +23,7 @@ import jakarta.validation.Valid;
 @RequestMapping("/auth")
 public class AuthController {
 	private final MemberService memberService;
+	private final int COOKIE_MAX_AGE = 5 * 60;
 
 	@Autowired
 	public AuthController(MemberService memberService) {
@@ -50,7 +51,7 @@ public class AuthController {
 			RefreshAccessTokenCommandDto.builder().refreshToken(refreshToken).build());
 
 		Cookie cookie = setCookie("accessToken", refreshAccessTokenResultDto.getAccessToken(),
-			new CookieOptions(true, "/", 5 * 60));
+			new CookieOptions(true, "/", COOKIE_MAX_AGE));
 		response.addCookie(cookie);
 
 		return ResponseEntity.ok().build();

--- a/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/AuthController.java
@@ -16,7 +16,6 @@ import com.tiketeer.Tiketeer.domain.member.service.dto.RefreshAccessTokenCommand
 import com.tiketeer.Tiketeer.domain.member.service.dto.RefreshAccessTokenResultDto;
 
 import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 
@@ -59,20 +58,6 @@ public class AuthController {
 	private String getRefreshToken(String authorizationHeader) {
 		if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
 			return authorizationHeader.substring(7);
-		}
-
-		throw new InvalidTokenException();
-	}
-
-	private String getAccessToken(HttpServletRequest request) {
-		if (request.getCookies() == null) {
-			throw new InvalidTokenException();
-		}
-
-		for (var cookie : request.getCookies()) {
-			if ("accessToken".equals(cookie.getName())) {
-				return cookie.getValue();
-			}
 		}
 
 		throw new InvalidTokenException();

--- a/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/AuthController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.tiketeer.Tiketeer.auth.constant.JwtMetadata;
 import com.tiketeer.Tiketeer.domain.member.constant.CookieConfig;
 import com.tiketeer.Tiketeer.domain.member.controller.dto.SetPasswordWithOtpRequestDto;
 import com.tiketeer.Tiketeer.domain.member.exception.InvalidTokenException;
@@ -51,7 +52,7 @@ public class AuthController {
 		RefreshAccessTokenResultDto refreshAccessTokenResultDto = memberService.refreshAccessToken(
 			RefreshAccessTokenCommandDto.builder().refreshToken(refreshToken).build());
 
-		Cookie cookie = setCookie("accessToken", refreshAccessTokenResultDto.getAccessToken(),
+		Cookie cookie = setCookie(JwtMetadata.ACCESS_TOKEN, refreshAccessTokenResultDto.getAccessToken(),
 			new CookieOptions(true, "/", CookieConfig.MAX_AGE));
 		response.addCookie(cookie);
 

--- a/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/AuthController.java
@@ -49,7 +49,8 @@ public class AuthController {
 		RefreshAccessTokenResultDto refreshAccessTokenResultDto = memberService.refreshAccessToken(
 			RefreshAccessTokenCommandDto.builder().refreshToken(refreshToken).build());
 
-		Cookie cookie = setCookie("accessToken", refreshAccessTokenResultDto.getAccessToken());
+		Cookie cookie = setCookie("accessToken", refreshAccessTokenResultDto.getAccessToken(),
+			new CookieOptions(true, "/", 5 * 60));
 		response.addCookie(cookie);
 
 		return ResponseEntity.ok().build();
@@ -63,12 +64,20 @@ public class AuthController {
 		throw new InvalidTokenException();
 	}
 
-	private Cookie setCookie(String key, String value) {
+	private Cookie setCookie(String key, String value, CookieOptions options) {
 		Cookie cookie = new Cookie(key, value);
-		cookie.setHttpOnly(true);
-		cookie.setPath("/");
-		cookie.setMaxAge(5 * 60);
-
+		if (options.httpOnly != null) {
+			cookie.setHttpOnly(options.httpOnly);
+		}
+		if (options.path != null) {
+			cookie.setPath(options.path);
+		}
+		if (options.maxAge != null) {
+			cookie.setMaxAge(options.maxAge);
+		}
 		return cookie;
+	}
+
+	public record CookieOptions(Boolean httpOnly, String path, Integer maxAge) {
 	}
 }

--- a/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/AuthController.java
@@ -4,15 +4,24 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.tiketeer.Tiketeer.domain.member.controller.dto.SetPasswordWithOtpRequestDto;
+import com.tiketeer.Tiketeer.domain.member.exception.InvalidTokenException;
 import com.tiketeer.Tiketeer.domain.member.service.MemberService;
 import com.tiketeer.Tiketeer.domain.member.service.dto.InitMemberPasswordWithOtpCommandDto;
+import com.tiketeer.Tiketeer.domain.member.service.dto.RefreshAccessTokenCommandDto;
+import com.tiketeer.Tiketeer.domain.member.service.dto.RefreshAccessTokenResultDto;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 
 @RestController
+@RequestMapping("/auth")
 public class AuthController {
 	private final MemberService memberService;
 
@@ -21,7 +30,7 @@ public class AuthController {
 		this.memberService = memberService;
 	}
 
-	@PostMapping(path = "/auth/otp/email")
+	@PostMapping(path = "/otp/email")
 	public ResponseEntity setPasswordWithOtp(@Valid @RequestBody SetPasswordWithOtpRequestDto request) {
 		memberService.initPasswordWithOtp(
 			InitMemberPasswordWithOtpCommandDto
@@ -31,5 +40,50 @@ public class AuthController {
 				.build()
 		);
 		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping(path = "/refresh")
+	public ResponseEntity refreshAccessToken(@RequestHeader("Authorization") String authorizationHeader,
+		HttpServletResponse response) {
+		String refreshToken = getRefreshToken(authorizationHeader);
+
+		RefreshAccessTokenResultDto refreshAccessTokenResultDto = memberService.refreshAccessToken(
+			RefreshAccessTokenCommandDto.builder().refreshToken(refreshToken).build());
+
+		Cookie cookie = setCookie("accessToken", refreshAccessTokenResultDto.getAccessToken());
+		response.addCookie(cookie);
+
+		return ResponseEntity.ok().build();
+	}
+
+	private String getRefreshToken(String authorizationHeader) {
+		if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+			return authorizationHeader.substring(7);
+		}
+
+		throw new InvalidTokenException();
+	}
+
+	private String getAccessToken(HttpServletRequest request) {
+		if (request.getCookies() == null) {
+			throw new InvalidTokenException();
+		}
+
+		for (var cookie : request.getCookies()) {
+			if ("accessToken".equals(cookie.getName())) {
+				return cookie.getValue();
+			}
+		}
+
+		throw new InvalidTokenException();
+	}
+
+	private Cookie setCookie(String key, String value) {
+		Cookie cookie = new Cookie(key, value);
+		cookie.setHttpOnly(true);
+		cookie.setPath("/");
+		cookie.setMaxAge(5 * 60);
+
+		return cookie;
 	}
 }

--- a/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/AuthController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.tiketeer.Tiketeer.domain.member.constant.CookieConfig;
 import com.tiketeer.Tiketeer.domain.member.controller.dto.SetPasswordWithOtpRequestDto;
 import com.tiketeer.Tiketeer.domain.member.exception.InvalidTokenException;
 import com.tiketeer.Tiketeer.domain.member.service.MemberService;
@@ -51,7 +52,7 @@ public class AuthController {
 			RefreshAccessTokenCommandDto.builder().refreshToken(refreshToken).build());
 
 		Cookie cookie = setCookie("accessToken", refreshAccessTokenResultDto.getAccessToken(),
-			new CookieOptions(true, "/", COOKIE_MAX_AGE));
+			new CookieOptions(true, "/", CookieConfig.MAX_AGE));
 		response.addCookie(cookie);
 
 		return ResponseEntity.ok().build();

--- a/src/main/java/com/tiketeer/Tiketeer/domain/member/exception/InvalidTokenException.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/member/exception/InvalidTokenException.java
@@ -1,0 +1,10 @@
+package com.tiketeer.Tiketeer.domain.member.exception;
+
+import com.tiketeer.Tiketeer.exception.DefinedException;
+import com.tiketeer.Tiketeer.exception.code.AuthExceptionCode;
+
+public class InvalidTokenException extends DefinedException {
+	public InvalidTokenException() {
+		super(AuthExceptionCode.NEED_LOGIN);
+	}
+}

--- a/src/main/java/com/tiketeer/Tiketeer/domain/member/service/MemberService.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/member/service/MemberService.java
@@ -1,13 +1,22 @@
 package com.tiketeer.Tiketeer.domain.member.service;
 
+import java.util.Date;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.tiketeer.Tiketeer.auth.jwt.JwtPayload;
+import com.tiketeer.Tiketeer.auth.jwt.JwtService;
 import com.tiketeer.Tiketeer.domain.member.exception.InvalidOtpException;
+import com.tiketeer.Tiketeer.domain.member.exception.InvalidTokenException;
 import com.tiketeer.Tiketeer.domain.member.repository.OtpRepository;
 import com.tiketeer.Tiketeer.domain.member.service.dto.InitMemberPasswordWithOtpCommandDto;
+import com.tiketeer.Tiketeer.domain.member.service.dto.RefreshAccessTokenCommandDto;
+import com.tiketeer.Tiketeer.domain.member.service.dto.RefreshAccessTokenResultDto;
+
+import io.jsonwebtoken.JwtException;
 
 @Service
 @Transactional(readOnly = true)
@@ -15,10 +24,13 @@ public class MemberService {
 	private final PasswordEncoder passwordEncoder;
 	private final OtpRepository otpRepository;
 
+	private final JwtService jwtService;
+
 	@Autowired
-	public MemberService(PasswordEncoder passwordEncoder, OtpRepository otpRepository) {
+	public MemberService(PasswordEncoder passwordEncoder, OtpRepository otpRepository, JwtService jwtService) {
 		this.passwordEncoder = passwordEncoder;
 		this.otpRepository = otpRepository;
+		this.jwtService = jwtService;
 	}
 
 	@Transactional
@@ -29,5 +41,18 @@ public class MemberService {
 		member.setPassword(passwordEncoder.encode(command.getPassword()));
 		member.setEnabled(true);
 		otpRepository.delete(otp);
+	}
+
+	public RefreshAccessTokenResultDto refreshAccessToken(RefreshAccessTokenCommandDto refreshAccessTokenCommandDto) {
+		var refreshToken = refreshAccessTokenCommandDto.getRefreshToken();
+
+		try {
+			JwtPayload jwtPayload = jwtService.verifyToken(refreshToken);
+			String newAccessToken = jwtService.createToken(
+				new JwtPayload(jwtPayload.email(), jwtPayload.roleEnum(), new Date(System.currentTimeMillis())));
+			return RefreshAccessTokenResultDto.toDto(newAccessToken);
+		} catch (JwtException ex) {
+			throw new InvalidTokenException();
+		}
 	}
 }

--- a/src/main/java/com/tiketeer/Tiketeer/domain/member/service/dto/RefreshAccessTokenCommandDto.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/member/service/dto/RefreshAccessTokenCommandDto.java
@@ -1,0 +1,16 @@
+package com.tiketeer.Tiketeer.domain.member.service.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(force = true)
+public class RefreshAccessTokenCommandDto {
+	private final String refreshToken;
+
+	@Builder
+	public RefreshAccessTokenCommandDto(String refreshToken) {
+		this.refreshToken = refreshToken;
+	}
+}

--- a/src/main/java/com/tiketeer/Tiketeer/domain/member/service/dto/RefreshAccessTokenResultDto.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/member/service/dto/RefreshAccessTokenResultDto.java
@@ -1,0 +1,20 @@
+package com.tiketeer.Tiketeer.domain.member.service.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(force = true)
+public class RefreshAccessTokenResultDto {
+	private final String accessToken;
+
+	@Builder
+	public RefreshAccessTokenResultDto(String accessToken) {
+		this.accessToken = accessToken;
+	}
+
+	public static RefreshAccessTokenResultDto toDto(String accessToken) {
+		return new RefreshAccessTokenResultDto(accessToken);
+	}
+}

--- a/src/main/java/com/tiketeer/Tiketeer/exception/code/AuthExceptionCode.java
+++ b/src/main/java/com/tiketeer/Tiketeer/exception/code/AuthExceptionCode.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 public enum AuthExceptionCode implements ExceptionCode {
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다. 재로그인이 필요합니다."),
 	WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "잘못된 패스워드입니다. 다시 시도해주십시오."),
+	NEED_LOGIN(HttpStatus.UNAUTHORIZED, "로그인이 필요한 서비스입니다. 다시 로그인해주십시오."),
+
 	INSUFFICIENT_PERMISSIONS(HttpStatus.FORBIDDEN, "작업을 수행할 권한이 부족합니다.");
 
 	private final HttpStatus httpStatus;

--- a/src/test/java/com/tiketeer/Tiketeer/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/tiketeer/Tiketeer/domain/member/service/MemberServiceTest.java
@@ -1,5 +1,7 @@
 package com.tiketeer.Tiketeer.domain.member.service;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.UUID;
@@ -33,26 +35,26 @@ import com.tiketeer.Tiketeer.testhelper.TestHelper;
 @Import({TestHelper.class})
 @SpringBootTest
 public class MemberServiceTest {
-	private final TestHelper testHelper;
-	private final MemberService memberService;
-	private final RoleRepository roleRepository;
-	private final MemberRepository memberRepository;
-	private final OtpRepository otpRepository;
-	private final PasswordEncoder passwordEncoder;
-	private final JwtService jwtService;
+	@Autowired
+	private TestHelper testHelper;
 
 	@Autowired
-	public MemberServiceTest(TestHelper testHelper, MemberService memberService, RoleRepository roleRepository,
-		MemberRepository memberRepository,
-		OtpRepository otpRepository, PasswordEncoder passwordEncoder, JwtService jwtService) {
-		this.testHelper = testHelper;
-		this.memberService = memberService;
-		this.roleRepository = roleRepository;
-		this.memberRepository = memberRepository;
-		this.otpRepository = otpRepository;
-		this.passwordEncoder = passwordEncoder;
-		this.jwtService = jwtService;
-	}
+	private MemberService memberService;
+
+	@Autowired
+	private RoleRepository roleRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private OtpRepository otpRepository;
+
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+
+	@Autowired
+	private JwtService jwtService;
 
 	@BeforeEach
 	void initTable() {
@@ -155,9 +157,9 @@ public class MemberServiceTest {
 
 		// when
 		// then
-		Assertions.assertThatThrownBy(() -> {
+		assertThrows(InvalidTokenException.class, () -> {
 			memberService.refreshAccessToken(
 				RefreshAccessTokenCommandDto.builder().refreshToken(refreshToken).build());
-		}).isInstanceOf(InvalidTokenException.class);
+		});
 	}
 }

--- a/src/test/java/com/tiketeer/Tiketeer/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/tiketeer/Tiketeer/domain/member/service/MemberServiceTest.java
@@ -146,7 +146,7 @@ public class MemberServiceTest {
 	}
 
 	@Test
-	@DisplayName("refreshToken 만료 > 재발급 > 재발급 확인")
+	@DisplayName("refreshToken 만료 > 재발급 > 예외발생 확인")
 	void refreshAccessTokenFailByExpiredRefreshToken() {
 		// given
 		String refreshToken = jwtService.createToken(


### PR DESCRIPTION
# 작업 내용
- /auth/refresh EP controller
- member service refreshAccessToken
- test 작성

## 고려 사항
- 재발급 과정에서 accessToken이 필요없을 것으로 보여서 accessToken은 받지 않는 쪽으로 구현했습니다. 왜냐면 어차피 refreshToken만 유효하면 무조건 발급해주면 되기 때문.