### PR TITLE
[DEV-116] 멤버 구매 내역 조회 정렬 순서 리팩토링

### DIFF
--- a/src/main/java/com/tiketeer/Tiketeer/domain/purchase/repository/PurchaseRepository.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/purchase/repository/PurchaseRepository.java
@@ -17,7 +17,7 @@ public interface PurchaseRepository extends JpaRepository<Purchase, UUID> {
 	@Query(
 		"SELECT new com.tiketeer.Tiketeer.domain.member.service.dto.GetMemberPurchasesResultDto(p.id, tg.id, tg.title, tg.location, tg.eventTime, tg.saleStart, tg.saleEnd, p.createdAt, tg.category, tg.price, count(*)) "
 			+ "FROM Purchase p LEFT JOIN Ticket t ON p = t.purchase LEFT JOIN Ticketing tg ON t.ticketing = tg "
-			+ "WHERE p.member = :member GROUP BY p, tg ORDER BY p.createdAt"
+			+ "WHERE p.member = :member GROUP BY p, tg ORDER BY p.createdAt, p.id"
 	)
 	List<GetMemberPurchasesResultDto> findWithTicketingByMember(@Param("member") Member member);
 }

--- a/src/test/java/com/tiketeer/Tiketeer/domain/member/usecase/GetMemberPurchasesUseCaseTest.java
+++ b/src/test/java/com/tiketeer/Tiketeer/domain/member/usecase/GetMemberPurchasesUseCaseTest.java
@@ -74,13 +74,21 @@ public class GetMemberPurchasesUseCaseTest {
 		// when
 		var results = getMemberPurchasesUseCase.getMemberPurchases(
 			GetMemberPurchasesCommandDto.builder().memberEmail(mockEmail).build());
+		var findPurchase1 = results.stream()
+			.filter(purchase -> purchase.getPurchaseId().equals(purchase1.getId()))
+			.toList();
+		var findPurchase2 = results.stream()
+			.filter(purchase -> purchase.getPurchaseId().equals(purchase2.getId()))
+			.toList();
 
 		// then
 		Assertions.assertThat(results.size()).isEqualTo(2);
-		Assertions.assertThat(results.get(0).getCount()).isEqualTo(2);
-		Assertions.assertThat(results.get(0).getTicketingId()).isEqualTo(ticketing1.getId());
-		Assertions.assertThat(results.get(1).getCount()).isEqualTo(1);
-		Assertions.assertThat(results.get(1).getTicketingId()).isEqualTo(ticketing2.getId());
+		Assertions.assertThat(findPurchase1.size()).isEqualTo(1);
+		Assertions.assertThat(findPurchase2.size()).isEqualTo(1);
+		Assertions.assertThat(findPurchase1.getFirst().getTitle()).isEqualTo(ticketing1.getTitle());
+		Assertions.assertThat(findPurchase2.getFirst().getTitle()).isEqualTo(ticketing2.getTitle());
+		Assertions.assertThat(findPurchase1.getFirst().getCount()).isEqualTo(2);
+		Assertions.assertThat(findPurchase2.getFirst().getCount()).isEqualTo(1);
 	}
 
 	@Test


### PR DESCRIPTION
- 작업 내용
  - createdAt가 동일한 경우 정렬시 조회 순서가 매번 변경되는 문제 해결
    - order by에 uuid 추가
  -  구매 내역 조회 test case 수정
    - 조회 순서가 생성 순서와 동일함이 보장되지 않아 테스트 로직 수정