### PR TITLE
[DEV-82] Purchase, Member, Ticketing 컨트롤러 테스트 작성

### DIFF
--- a/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/MemberController.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/MemberController.java
@@ -115,7 +115,7 @@ public class MemberController {
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}
 
-	@GetMapping()
+	@GetMapping
 	public ResponseEntity<ApiResponse<GetMemberResponseDto>> getMember() {
 		var email = securityContextHelper.getEmailInToken();
 		var result = getMemberUseCase.get(GetMemberCommandDto.builder().memberEmail(email).build());

--- a/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/dto/GetMemberResponseDto.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/dto/GetMemberResponseDto.java
@@ -6,10 +6,12 @@ import com.tiketeer.Tiketeer.domain.member.usecase.dto.GetMemberResultDto;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
 @ToString
+@NoArgsConstructor(force = true)
 public class GetMemberResponseDto {
 	private String email;
 	private LocalDateTime createdAt;

--- a/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/dto/ResetPasswordRequestDto.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/member/controller/dto/ResetPasswordRequestDto.java
@@ -7,10 +7,12 @@ import com.tiketeer.Tiketeer.domain.member.usecase.dto.ResetPasswordCommandDto;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
 @ToString
+@NoArgsConstructor(force = true)
 public class ResetPasswordRequestDto {
 
 	@NotBlank

--- a/src/main/java/com/tiketeer/Tiketeer/domain/purchase/controller/PurchaseController.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/purchase/controller/PurchaseController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.tiketeer.Tiketeer.auth.SecurityContextHelper;
 import com.tiketeer.Tiketeer.domain.purchase.controller.dto.DeletePurchaseTicketsRequestDto;
 import com.tiketeer.Tiketeer.domain.purchase.controller.dto.PostPurchaseRequestDto;
 import com.tiketeer.Tiketeer.domain.purchase.controller.dto.PostPurchaseResponseDto;
@@ -26,27 +27,29 @@ import jakarta.validation.Valid;
 public class PurchaseController {
 	private final CreatePurchaseUseCase createPurchaseUseCase;
 	private final DeletePurchaseTicketsUseCase deletePurchaseTicketsUseCase;
+	private final SecurityContextHelper securityContextHelper;
 
 	@Autowired
 	PurchaseController(CreatePurchaseUseCase createPurchaseUseCase,
-		DeletePurchaseTicketsUseCase deletePurchaseTicketsUseCase) {
+		DeletePurchaseTicketsUseCase deletePurchaseTicketsUseCase, SecurityContextHelper securityContextHelper) {
 		this.createPurchaseUseCase = createPurchaseUseCase;
 		this.deletePurchaseTicketsUseCase = deletePurchaseTicketsUseCase;
+		this.securityContextHelper = securityContextHelper;
 	}
 
-	@PostMapping("/")
+	@PostMapping
 	public ResponseEntity<ApiResponse<PostPurchaseResponseDto>> postPurchase(
 		@Valid @RequestBody PostPurchaseRequestDto request) {
-		var memberEmail = "mock@mock.com";
+		var memberEmail = securityContextHelper.getEmailInToken();
 		var result = createPurchaseUseCase.createPurchase(request.convertToDto(memberEmail));
 		var responseBody = ApiResponse.wrap(PostPurchaseResponseDto.converFromDto(result));
 		return ResponseEntity.status(HttpStatus.CREATED).body(responseBody);
 	}
 
 	@DeleteMapping("/{purchaseId}/tickets")
-	public ResponseEntity deletePurchaseTickets(@PathVariable UUID purchaseId, @Valid @RequestBody
-	DeletePurchaseTicketsRequestDto request) {
-		var memberEmail = "mock@mock.com";
+	public ResponseEntity deletePurchaseTickets(@PathVariable UUID purchaseId,
+		@Valid @RequestBody DeletePurchaseTicketsRequestDto request) {
+		var memberEmail = securityContextHelper.getEmailInToken();
 		deletePurchaseTicketsUseCase.deletePurchaseTickets(request.convertToDto(memberEmail, purchaseId));
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}

--- a/src/main/java/com/tiketeer/Tiketeer/domain/purchase/controller/dto/PostPurchaseRequestDto.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/purchase/controller/dto/PostPurchaseRequestDto.java
@@ -7,10 +7,12 @@ import com.tiketeer.Tiketeer.domain.purchase.usecase.dto.CreatePurchaseCommandDt
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
 @ToString
+@NoArgsConstructor(force = true)
 public class PostPurchaseRequestDto {
 	@NotNull
 	private final UUID ticketingId;

--- a/src/main/java/com/tiketeer/Tiketeer/domain/purchase/controller/dto/PostPurchaseResponseDto.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/purchase/controller/dto/PostPurchaseResponseDto.java
@@ -7,10 +7,12 @@ import com.tiketeer.Tiketeer.domain.purchase.usecase.dto.CreatePurchaseResultDto
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
 @ToString
+@NoArgsConstructor(force = true)
 public class PostPurchaseResponseDto {
 	private final UUID purchaseId;
 	private LocalDateTime createdAt;

--- a/src/main/java/com/tiketeer/Tiketeer/domain/ticketing/controller/TicketingController.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/ticketing/controller/TicketingController.java
@@ -51,7 +51,7 @@ public class TicketingController {
 		this.deleteTicketingUseCase = deleteTicketingUseCase;
 	}
 
-	@GetMapping(path = "/")
+	@GetMapping()
 	public ResponseEntity<ApiResponse<List<GetAllTicketingsResponseDto>>> getAllTicketings() {
 		var results = ticketingService.getAllTicketings();
 		var responseBody = ApiResponse.wrap(
@@ -63,6 +63,7 @@ public class TicketingController {
 	public ResponseEntity<ApiResponse<GetTicketingResponseDto>> getTicketing(@PathVariable UUID ticketingId) {
 		var result = ticketingService.getTickting(
 			GetTicketingCommandDto.builder().ticketingId(ticketingId).build());
+
 		var responseBody = ApiResponse.wrap(GetTicketingResponseDto.convertFromDto(result));
 		return ResponseEntity.status(HttpStatus.OK).body(responseBody);
 	}

--- a/src/main/java/com/tiketeer/Tiketeer/domain/ticketing/controller/TicketingController.java
+++ b/src/main/java/com/tiketeer/Tiketeer/domain/ticketing/controller/TicketingController.java
@@ -51,7 +51,7 @@ public class TicketingController {
 		this.deleteTicketingUseCase = deleteTicketingUseCase;
 	}
 
-	@GetMapping()
+	@GetMapping
 	public ResponseEntity<ApiResponse<List<GetAllTicketingsResponseDto>>> getAllTicketings() {
 		var results = ticketingService.getAllTicketings();
 		var responseBody = ApiResponse.wrap(

--- a/src/main/java/com/tiketeer/Tiketeer/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tiketeer/Tiketeer/exception/GlobalExceptionHandler.java
@@ -5,21 +5,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import com.tiketeer.Tiketeer.domain.member.exception.DuplicatedEmailException;
-import com.tiketeer.Tiketeer.domain.member.exception.InvalidLoginException;
-import com.tiketeer.Tiketeer.domain.member.exception.InvalidNewPasswordException;
-import com.tiketeer.Tiketeer.domain.member.exception.InvalidOtpException;
-import com.tiketeer.Tiketeer.domain.member.exception.InvalidPointChargeRequestException;
-import com.tiketeer.Tiketeer.domain.member.exception.MemberIdAndAuthNotMatchedException;
-import com.tiketeer.Tiketeer.domain.member.exception.MemberNotFoundException;
-import com.tiketeer.Tiketeer.domain.role.exception.RoleNotFoundException;
-import com.tiketeer.Tiketeer.domain.ticket.exception.TicketNotFoundException;
-import com.tiketeer.Tiketeer.domain.ticketing.exception.DeleteTicketingAfterSaleStartException;
-import com.tiketeer.Tiketeer.domain.ticketing.exception.EventTimeNotValidException;
-import com.tiketeer.Tiketeer.domain.ticketing.exception.ModifyForNotOwnedTicketingException;
-import com.tiketeer.Tiketeer.domain.ticketing.exception.SaleDurationNotValidException;
-import com.tiketeer.Tiketeer.domain.ticketing.exception.TicketingNotFoundException;
-import com.tiketeer.Tiketeer.domain.ticketing.exception.UpdateTicketingAfterSaleStartException;
 import com.tiketeer.Tiketeer.exception.code.CommonExceptionCode;
 import com.tiketeer.Tiketeer.exception.code.ExceptionCode;
 
@@ -28,30 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
-	@ExceptionHandler({
-		// Member
-		DuplicatedEmailException.class,
-		MemberNotFoundException.class,
-		InvalidOtpException.class,
-		InvalidLoginException.class,
-		MemberIdAndAuthNotMatchedException.class,
-		InvalidPointChargeRequestException.class,
-		InvalidNewPasswordException.class,
-
-		// Ticketing
-		TicketingNotFoundException.class,
-		EventTimeNotValidException.class,
-		SaleDurationNotValidException.class,
-		UpdateTicketingAfterSaleStartException.class,
-		DeleteTicketingAfterSaleStartException.class,
-		ModifyForNotOwnedTicketingException.class,
-
-		// Ticket
-		TicketNotFoundException.class,
-
-		// Role
-		RoleNotFoundException.class
-	})
+	@ExceptionHandler(DefinedException.class)
 	protected ResponseEntity<ErrorResponse> handleDefinedException(final DefinedException ex) {
 		logError(ex);
 		return createErrorResponse(ex.getExceptionCode());

--- a/src/test/java/com/tiketeer/Tiketeer/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/tiketeer/Tiketeer/domain/member/controller/MemberControllerTest.java
@@ -226,13 +226,12 @@ class MemberControllerTest {
 
 	@Test
 	@DisplayName("정상 조건 > 멤버 조회 > 성공")
-	@Transactional
 	void getMemberSuccess() throws Exception {
 		//given
 		String token = testHelper.registerAndLoginAndReturnAccessToken("user@example.com", RoleEnum.SELLER);
 		Member memberInDb = memberRepository.findAll().getFirst();
 		Cookie cookie = new Cookie(JwtMetadata.ACCESS_TOKEN, token);
-		System.out.print("send request");
+
 		//when
 		var result = mockMvc.perform(get("/api/members")
 				.contextPath("/api")

--- a/src/test/java/com/tiketeer/Tiketeer/domain/purchase/controller/PurchaseControllerTest.java
+++ b/src/test/java/com/tiketeer/Tiketeer/domain/purchase/controller/PurchaseControllerTest.java
@@ -1,0 +1,423 @@
+package com.tiketeer.Tiketeer.domain.purchase.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Limit;
+import org.springframework.data.util.Pair;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tiketeer.Tiketeer.auth.constant.JwtMetadata;
+import com.tiketeer.Tiketeer.domain.member.Member;
+import com.tiketeer.Tiketeer.domain.member.repository.MemberRepository;
+import com.tiketeer.Tiketeer.domain.purchase.Purchase;
+import com.tiketeer.Tiketeer.domain.purchase.controller.dto.DeletePurchaseTicketsRequestDto;
+import com.tiketeer.Tiketeer.domain.purchase.controller.dto.PostPurchaseRequestDto;
+import com.tiketeer.Tiketeer.domain.purchase.exception.NotEnoughTicketException;
+import com.tiketeer.Tiketeer.domain.purchase.repository.PurchaseRepository;
+import com.tiketeer.Tiketeer.domain.role.constant.RoleEnum;
+import com.tiketeer.Tiketeer.domain.ticket.Ticket;
+import com.tiketeer.Tiketeer.domain.ticket.repository.TicketRepository;
+import com.tiketeer.Tiketeer.domain.ticketing.Ticketing;
+import com.tiketeer.Tiketeer.domain.ticketing.repository.TicketingRepository;
+import com.tiketeer.Tiketeer.testhelper.TestHelper;
+
+import jakarta.servlet.http.Cookie;
+
+@Import({TestHelper.class})
+@SpringBootTest
+@AutoConfigureMockMvc
+public class PurchaseControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private TestHelper testHelper;
+	@Autowired
+	private PurchaseRepository purchaseRepository;
+	@Autowired
+	private TicketingRepository ticketingRepository;
+	@Autowired
+	private TicketRepository ticketRepository;
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@BeforeEach
+	void initDB() {
+		testHelper.initDB();
+	}
+
+	@AfterEach
+	void cleanDB() {
+		testHelper.cleanDB();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("정상 조건 > 구매 생성 요청 > 성공")
+	void postPurchaseSuccess() throws Exception {
+		// given
+		String token = testHelper.registerAndLoginAndReturnAccessToken("user@example.com", RoleEnum.SELLER);
+		Member member = memberRepository.findAll().getFirst();
+		Cookie cookie = new Cookie(JwtMetadata.ACCESS_TOKEN, token);
+		var ticketing = createTicketing(member, 0, 2);
+
+		var count = 2;
+		PostPurchaseRequestDto req = PostPurchaseRequestDto.builder()
+			.ticketingId(ticketing.getId())
+			.count(count)
+			.build();
+		String content = objectMapper.writeValueAsString(req);
+
+		// when
+		mockMvc
+			.perform(post("/api/purchases")
+				.contextPath("/api")
+				.contentType(MediaType.APPLICATION_JSON)
+				.characterEncoding("utf-8")
+				.content(content)
+				.cookie(cookie)
+			)
+			//then
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.data.purchaseId").value(purchaseRepository.findAll().getFirst().getId().toString()
+			));
+		// System.out.println("print response content");
+		// System.out.println(result.andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8));
+		// ApiResponse response = objectMapper.readValue(
+		// 	result.andReturn().getResponse().getContentAsString(),
+		// 	ApiResponse.class);
+		// PostPurchaseResponseDto dto = objectMapper.convertValue(response.getData(), PostPurchaseResponseDto.class);
+		// System.out.println("print PostPurchaseResponseDto");
+		// var purchases = purchaseRepository.findAll();
+		//
+		// //then
+		// Assertions.assertThat(purchases.size()).isEqualTo(1);
+		// result
+		// 	.andExpect(status().isCreated())
+		// 	.andExpect(jsonPath("$.data.purchaseId").value(purchases.getFirst().getId().toString()
+		// 	));
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("티케팅 판매 기간이 아님 > 구매 생성 요청 > 실패")
+	void postPurchaseFailNotInSalePeriod() throws Exception {
+		// given
+		String token = testHelper.registerAndLoginAndReturnAccessToken("user@example.com", RoleEnum.SELLER);
+		Member member = memberRepository.findAll().getFirst();
+		Cookie cookie = new Cookie(JwtMetadata.ACCESS_TOKEN, token);
+		var ticketing = createTicketing(member, 1, 2);
+
+		var count = 2;
+		PostPurchaseRequestDto req = PostPurchaseRequestDto.builder()
+			.ticketingId(ticketing.getId())
+			.count(count)
+			.build();
+		String content = objectMapper.writeValueAsString(req);
+
+		// when
+		mockMvc
+			.perform(post("/api/purchases")
+				.contextPath("/api")
+				.contentType(MediaType.APPLICATION_JSON)
+				.characterEncoding("utf-8")
+				.content(content)
+				.cookie(cookie)
+			)
+			//then
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("구매 가능한 티켓이 부족 > 구매 생성 요청 > 실패")
+	void postPurchaseFailNotEnoughTicket() throws Exception {
+		// given
+		String token = testHelper.registerAndLoginAndReturnAccessToken("user@example.com", RoleEnum.SELLER);
+		Member member = memberRepository.findAll().getFirst();
+		Cookie cookie = new Cookie(JwtMetadata.ACCESS_TOKEN, token);
+		var ticketing = createTicketing(member, 0, 2);
+
+		var count = 3;
+		PostPurchaseRequestDto req = PostPurchaseRequestDto.builder()
+			.ticketingId(ticketing.getId())
+			.count(count)
+			.build();
+		String content = objectMapper.writeValueAsString(req);
+
+		// when
+		mockMvc
+			.perform(post("/api/purchases")
+				.contextPath("/api")
+				.contentType(MediaType.APPLICATION_JSON)
+				.characterEncoding("utf-8")
+				.content(content)
+				.cookie(cookie)
+			)
+			//then
+			.andExpect(status().isConflict());
+	}
+
+	@Test
+	@DisplayName("구매 내역 일부 환불 > 티켓 환불 요청 > 성공")
+	@Transactional
+	void deletePurchaseTicketsSuccess() throws Exception {
+		// given
+		String token = testHelper.registerAndLoginAndReturnAccessToken("user@example.com", RoleEnum.SELLER);
+		Member member = memberRepository.findAll().getFirst();
+		Cookie cookie = new Cookie(JwtMetadata.ACCESS_TOKEN, token);
+		var ticketing = createTicketing(member, 0, 2);
+		var purchaseTicketPair = createPurchase(member, ticketing, 2);
+		var purchase = purchaseTicketPair.getFirst();
+		var tickets = purchaseTicketPair.getSecond();
+
+		List<UUID> ticketsToRefund = Collections.singletonList(tickets.getFirst().getId());
+		DeletePurchaseTicketsRequestDto req = DeletePurchaseTicketsRequestDto.builder()
+			.purchaseId(purchase.getId())
+			.ticketIds(ticketsToRefund)
+			.build();
+		String content = objectMapper.writeValueAsString(req);
+
+		// when
+		mockMvc
+			.perform(delete("/api/purchases/{purchaseId}/tickets", purchase.getId())
+				.contextPath("/api")
+				.contentType(MediaType.APPLICATION_JSON)
+				.characterEncoding("utf-8")
+				.content(content)
+				.cookie(cookie)
+			)
+			//then
+			.andExpect(status().isOk());
+		Assertions.assertThat(ticketRepository.findAllByPurchase(purchase).size()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("구매 내역 전체 환불 > 티켓 환불 요청 > 성공")
+	@Transactional
+	void deletePurchaseAllTicketsSuccess() throws Exception {
+		// given
+		String token = testHelper.registerAndLoginAndReturnAccessToken("user@example.com", RoleEnum.SELLER);
+		Member member = memberRepository.findAll().getFirst();
+		Cookie cookie = new Cookie(JwtMetadata.ACCESS_TOKEN, token);
+		var ticketing = createTicketing(member, 0, 2);
+		var purchaseTicketPair = createPurchase(member, ticketing, 2);
+		var purchase = purchaseTicketPair.getFirst();
+		var tickets = purchaseTicketPair.getSecond();
+
+		List<UUID> ticketsToRefund = tickets.stream().map(Ticket::getId).toList();
+		DeletePurchaseTicketsRequestDto req = DeletePurchaseTicketsRequestDto.builder()
+			.purchaseId(purchase.getId())
+			.ticketIds(ticketsToRefund)
+			.build();
+		String content = objectMapper.writeValueAsString(req);
+
+		// when
+		mockMvc
+			.perform(delete("/api/purchases/{purchaseId}/tickets", purchase.getId())
+				.contextPath("/api")
+				.contentType(MediaType.APPLICATION_JSON)
+				.characterEncoding("utf-8")
+				.content(content)
+				.cookie(cookie)
+			)
+			//then
+			.andExpect(status().isOk());
+		Assertions.assertThat(purchaseRepository.findById(purchase.getId())).isEmpty();
+		Assertions.assertThat(ticketRepository.findAllByPurchase(purchase).size()).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("구매 내역이 존재하지 않음 > 티켓 환불 요청 > 실패")
+	@Transactional
+	void deletePurchaseTicketsFailPurchaseNotFound() throws Exception {
+		// given
+		String token = testHelper.registerAndLoginAndReturnAccessToken("user@example.com", RoleEnum.SELLER);
+		Member member = memberRepository.findAll().getFirst();
+		Cookie cookie = new Cookie(JwtMetadata.ACCESS_TOKEN, token);
+		var notExistedPurchaseId = UUID.randomUUID();
+
+		List<UUID> ticketsToRefund = Collections.singletonList(UUID.randomUUID());
+		DeletePurchaseTicketsRequestDto req = DeletePurchaseTicketsRequestDto.builder()
+			.purchaseId(notExistedPurchaseId)
+			.ticketIds(ticketsToRefund)
+			.build();
+		String content = objectMapper.writeValueAsString(req);
+
+		// when
+		mockMvc
+			.perform(delete("/api/purchases/{purchaseId}/tickets", notExistedPurchaseId)
+				.contextPath("/api")
+				.contentType(MediaType.APPLICATION_JSON)
+				.characterEncoding("utf-8")
+				.content(content)
+				.cookie(cookie)
+			)
+			//then
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	@DisplayName("빈 구매 내역 > 티켓 환불 요청 > 실패")
+	@Transactional
+	void deletePurchaseTicketsFailEmptyPurchase() throws Exception {
+		// given
+		String token = testHelper.registerAndLoginAndReturnAccessToken("user@example.com", RoleEnum.SELLER);
+		Member member = memberRepository.findAll().getFirst();
+		Cookie cookie = new Cookie(JwtMetadata.ACCESS_TOKEN, token);
+		var ticketing = createTicketing(member, 0, 5);
+		var purchaseTicketPair = createPurchase(member, ticketing, 0);
+		var purchase = purchaseTicketPair.getFirst();
+
+		List<UUID> ticketsToRefund = Collections.singletonList(UUID.randomUUID());
+		DeletePurchaseTicketsRequestDto req = DeletePurchaseTicketsRequestDto.builder()
+			.purchaseId(purchase.getId())
+			.ticketIds(ticketsToRefund)
+			.build();
+		String content = objectMapper.writeValueAsString(req);
+
+		// when
+		mockMvc
+			.perform(delete("/api/purchases/{purchaseId}/tickets", purchase.getId())
+				.contextPath("/api")
+				.contentType(MediaType.APPLICATION_JSON)
+				.characterEncoding("utf-8")
+				.content(content)
+				.cookie(cookie)
+			)
+			//then
+			.andExpect(status().isConflict());
+	}
+
+	@Test
+	@DisplayName("구매 내역 소유자가 아님 > 티켓 환불 요청 > 실패")
+	@Transactional
+	void deletePurchaseTicketsFailNotPurchaseOwner() throws Exception {
+		// given
+		String token = testHelper.registerAndLoginAndReturnAccessToken("user@example.com", RoleEnum.SELLER);
+		Member member = testHelper.createMember("otherUser@example.com");
+		Cookie cookie = new Cookie(JwtMetadata.ACCESS_TOKEN, token);
+		var ticketing = createTicketing(member, 0, 2);
+		var purchaseTicketPair = createPurchase(member, ticketing, 2);
+		var purchase = purchaseTicketPair.getFirst();
+		var tickets = purchaseTicketPair.getSecond();
+
+		List<UUID> ticketsToRefund = Collections.singletonList(tickets.getFirst().getId());
+		DeletePurchaseTicketsRequestDto req = DeletePurchaseTicketsRequestDto.builder()
+			.purchaseId(purchase.getId())
+			.ticketIds(ticketsToRefund)
+			.build();
+		String content = objectMapper.writeValueAsString(req);
+
+		// when
+		mockMvc
+			.perform(delete("/api/purchases/{purchaseId}/tickets", purchase.getId())
+				.contextPath("/api")
+				.contentType(MediaType.APPLICATION_JSON)
+				.characterEncoding("utf-8")
+				.content(content)
+				.cookie(cookie)
+			)
+			//then
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	@DisplayName("티켓팅 판매 기간이 아님 > 티켓 환불 요청 > 실패")
+	@Transactional
+	void deletePurchaseTicketsFailNotTicketingSalePeriod() throws Exception {
+		// given
+		String token = testHelper.registerAndLoginAndReturnAccessToken("user@example.com", RoleEnum.SELLER);
+		Member member = memberRepository.findAll().getFirst();
+		Cookie cookie = new Cookie(JwtMetadata.ACCESS_TOKEN, token);
+		var ticketing = createTicketing(member, 1, 2);
+		var purchaseTicketPair = createPurchase(member, ticketing, 2);
+		var purchase = purchaseTicketPair.getFirst();
+		var tickets = purchaseTicketPair.getSecond();
+
+		List<UUID> ticketsToRefund = Collections.singletonList(tickets.getFirst().getId());
+		DeletePurchaseTicketsRequestDto req = DeletePurchaseTicketsRequestDto.builder()
+			.purchaseId(purchase.getId())
+			.ticketIds(ticketsToRefund)
+			.build();
+		String content = objectMapper.writeValueAsString(req);
+
+		// when
+		mockMvc
+			.perform(delete("/api/purchases/{purchaseId}/tickets", purchase.getId())
+				.contextPath("/api")
+				.contentType(MediaType.APPLICATION_JSON)
+				.characterEncoding("utf-8")
+				.content(content)
+				.cookie(cookie)
+			)
+			//then
+			.andExpect(status().isBadRequest());
+	}
+
+	private Ticketing createTicketing(Member member, int saleStartAfterYears, int stock) {
+		var now = LocalDateTime.now();
+		var eventTime = now.plusYears(saleStartAfterYears + 2);
+		var saleStart = now.plusYears(saleStartAfterYears);
+		var saleEnd = now.plusYears(saleStartAfterYears + 1);
+		var ticketing = ticketingRepository.save(Ticketing.builder()
+			.price(1000)
+			.title("test")
+			.member(member)
+			.description("")
+			.location("Seoul")
+			.eventTime(eventTime)
+			.saleStart(saleStart)
+			.saleEnd(saleEnd)
+			.category("concert")
+			.runningMinutes(300).build());
+		ticketRepository.saveAll(Arrays.stream(new int[stock])
+			.mapToObj(i -> Ticket.builder().ticketing(ticketing).build())
+			.toList());
+		return ticketing;
+	}
+
+	private Pair<Purchase, List<Ticket>> createPurchase(Member member, Ticketing ticketing, int count) {
+		var purchase = this.purchaseRepository.save(Purchase.builder().member(member).build());
+
+		if (count > 0) {
+			var tickets = updateTicketPurchase(purchase, ticketing, count);
+			return Pair.of(purchase, tickets);
+		}
+		return Pair.of(purchase, Collections.emptyList());
+	}
+
+	private List<Ticket> updateTicketPurchase(Purchase purchase, Ticketing ticketing, int count) {
+		var tickets = this.ticketRepository.findByTicketingIdAndPurchaseIsNullOrderById(ticketing.getId(),
+			Limit.of(count));
+		if (tickets.size() < count) {
+			throw new NotEnoughTicketException();
+		}
+		tickets.forEach(ticket -> {
+			ticket.setPurchase(purchase);
+			this.ticketRepository.save(ticket);
+		});
+		return tickets;
+	}
+}

--- a/src/test/java/com/tiketeer/Tiketeer/domain/purchase/controller/PurchaseControllerTest.java
+++ b/src/test/java/com/tiketeer/Tiketeer/domain/purchase/controller/PurchaseControllerTest.java
@@ -102,21 +102,6 @@ public class PurchaseControllerTest {
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.data.purchaseId").value(purchaseRepository.findAll().getFirst().getId().toString()
 			));
-		// System.out.println("print response content");
-		// System.out.println(result.andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8));
-		// ApiResponse response = objectMapper.readValue(
-		// 	result.andReturn().getResponse().getContentAsString(),
-		// 	ApiResponse.class);
-		// PostPurchaseResponseDto dto = objectMapper.convertValue(response.getData(), PostPurchaseResponseDto.class);
-		// System.out.println("print PostPurchaseResponseDto");
-		// var purchases = purchaseRepository.findAll();
-		//
-		// //then
-		// Assertions.assertThat(purchases.size()).isEqualTo(1);
-		// result
-		// 	.andExpect(status().isCreated())
-		// 	.andExpect(jsonPath("$.data.purchaseId").value(purchases.getFirst().getId().toString()
-		// 	));
 	}
 
 	@Test

--- a/src/test/java/com/tiketeer/Tiketeer/domain/ticketing/controller/TicketingControllerTest.java
+++ b/src/test/java/com/tiketeer/Tiketeer/domain/ticketing/controller/TicketingControllerTest.java
@@ -1,0 +1,152 @@
+package com.tiketeer.Tiketeer.domain.ticketing.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tiketeer.Tiketeer.domain.member.Member;
+import com.tiketeer.Tiketeer.domain.member.repository.MemberRepository;
+import com.tiketeer.Tiketeer.domain.purchase.repository.PurchaseRepository;
+import com.tiketeer.Tiketeer.domain.role.constant.RoleEnum;
+import com.tiketeer.Tiketeer.domain.ticket.Ticket;
+import com.tiketeer.Tiketeer.domain.ticket.repository.TicketRepository;
+import com.tiketeer.Tiketeer.domain.ticketing.Ticketing;
+import com.tiketeer.Tiketeer.domain.ticketing.controller.dto.GetAllTicketingsResponseDto;
+import com.tiketeer.Tiketeer.domain.ticketing.controller.dto.GetTicketingResponseDto;
+import com.tiketeer.Tiketeer.domain.ticketing.repository.TicketingRepository;
+import com.tiketeer.Tiketeer.response.ApiResponse;
+import com.tiketeer.Tiketeer.testhelper.TestHelper;
+
+@Import({TestHelper.class})
+@SpringBootTest
+@AutoConfigureMockMvc
+public class TicketingControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private TestHelper testHelper;
+	@Autowired
+	private MemberRepository memberRepository;
+	@Autowired
+	private PurchaseRepository purchaseRepository;
+	@Autowired
+	private TicketingRepository ticketingRepository;
+	@Autowired
+	private TicketRepository ticketRepository;
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@BeforeEach
+	void initDB() {
+		testHelper.initDB();
+	}
+
+	@AfterEach
+	void cleanDB() {
+		testHelper.cleanDB();
+	}
+
+	@Test
+	@DisplayName("정상 조건 > 티켓팅 전체 조회 요청 > 성공")
+	@Transactional
+	void getAllTicketingsSuccess() throws Exception {
+		// given
+		var member = testHelper.createMember("user@example.com", RoleEnum.SELLER);
+		var ticketCnt = 3;
+		createTicketings(member, ticketCnt);
+
+		// when
+		var result = mockMvc.perform(get("/api/ticketings")
+				.contextPath("/api")
+				.contentType(MediaType.APPLICATION_JSON)
+				.characterEncoding("utf-8")
+			)
+			//then
+			.andExpect(status().isOk());
+
+		ApiResponse<List<GetAllTicketingsResponseDto>> apiResponse = testHelper.getDeserializedListApiResponse(
+			result.andReturn().getResponse().getContentAsString(), GetAllTicketingsResponseDto.class);
+
+		var ticketings = apiResponse.getData();
+		// then
+		Assertions.assertThat(ticketings.size()).isEqualTo(ticketCnt);
+		IntStream.range(0, ticketCnt).forEach(idx -> {
+			Assertions.assertThat(ticketings.get(idx).getTitle()).isEqualTo(idx + "");
+		});
+
+	}
+
+	@Test
+	@DisplayName("정상 조건 > 특정 티켓팅 조회 요청 > 성공")
+	@Transactional
+	void getTicketingSuccess() throws Exception {
+		// given
+		var member = testHelper.createMember("user@example.com", RoleEnum.SELLER);
+		var ticketingInDb = createTicketings(member, 1).getFirst();
+		var stock = 10;
+		createTickets(ticketingInDb, stock);
+
+		// when
+		var result = mockMvc.perform(get("/api/ticketings/{ticketingId}", ticketingInDb.getId())
+				.contextPath("/api")
+				.contentType(MediaType.APPLICATION_JSON)
+				.characterEncoding("utf-8")
+			)
+			//then
+			.andExpect(status().isOk());
+
+		ApiResponse<GetTicketingResponseDto> apiResponse = testHelper.getDeserializedApiResponse(
+			result.andReturn().getResponse().getContentAsString(), GetTicketingResponseDto.class);
+		var ticketing = apiResponse.getData();
+		Assertions.assertThat(ticketing.getTitle()).isEqualTo("0");
+		Assertions.assertThat(ticketing.getStock()).isEqualTo(stock);
+		Assertions.assertThat(ticketing.getRemainedStock()).isEqualTo(stock);
+		Assertions.assertThat(ticketing.getOwner()).isEqualTo(member.getEmail());
+	}
+
+	private List<Ticketing> createTicketings(Member member, int count) {
+		List<String> titles = new ArrayList<>(count);
+		for (int i = 0; i < count; i++) {
+			titles.add(i + "");
+		}
+		var ticketings = titles.stream().map(title ->
+			Ticketing.builder()
+				.member(member)
+				.title(title)
+				.location("서울")
+				.category("콘서트")
+				.runningMinutes(100)
+				.price(10000)
+				.eventTime(LocalDateTime.now().plusMonths(2))
+				.saleStart(LocalDateTime.now().minusMonths(1))
+				.saleEnd(LocalDateTime.now().plusMonths(1))
+				.build()
+		).toList();
+		return ticketingRepository.saveAll(ticketings);
+	}
+
+	private List<Ticket> createTickets(Ticketing ticketing, int stock) {
+		return ticketRepository.saveAll(Arrays.stream(new int[stock])
+			.mapToObj(i -> Ticket.builder().ticketing(ticketing).build())
+			.toList());
+	}
+}

--- a/src/test/java/com/tiketeer/Tiketeer/testhelper/TestHelper.java
+++ b/src/test/java/com/tiketeer/Tiketeer/testhelper/TestHelper.java
@@ -139,6 +139,11 @@ public class TestHelper {
 	}
 
 	@Transactional
+	public Member createMember(String email, RoleEnum roleEnum) {
+		return createMember(email, "1q2w3e4r!!", roleEnum);
+	}
+
+	@Transactional
 	public Member createMember(String email, String password, RoleEnum roleEnum) {
 		var role = roleRepository.findByName(roleEnum).orElseThrow();
 		return memberRepository.save(Member.builder()

--- a/src/test/java/com/tiketeer/Tiketeer/testhelper/TestHelperTest.java
+++ b/src/test/java/com/tiketeer/Tiketeer/testhelper/TestHelperTest.java
@@ -198,6 +198,30 @@ public class TestHelperTest {
 	}
 
 	@Test
+	@DisplayName("이메일, 역할 지정 > 멤버 생성 요청 > 이메일, 역할이 지정된 멤버 생성 (나머지는 메서드 내 기본 값)")
+	@Transactional
+	void createMemberEmailAndRoleParamSuccess() {
+		// given
+		testHelper.initDB();
+
+		var email = "test@test.com";
+		var role = RoleEnum.SELLER;
+
+		// when
+		var memberId = testHelper.createMember(email, role).getId();
+
+		// then
+		var memberOpt = memberRepository.findById(memberId);
+		assertThat(memberOpt.isPresent()).isTrue();
+
+		var member = memberOpt.get();
+		assertThat(member.getEmail()).isEqualTo(email);
+		assertThat(passwordEncoder.matches("1q2w3e4r!!", member.getPassword())).isTrue();
+		assertThat(member.getRole().getName()).isEqualTo(role);
+		defaultMemberPropertiesTest(member);
+	}
+
+	@Test
 	@DisplayName("이메일, 패스워드, 역할 지정 > 멤버 생성 요청 > 이메일, 패스워드, 역할이 지정된 멤버 생성 (나머지는 메서드 내 기본 값)")
 	@Transactional
 	void createMemberEmailAndPasswordAndRoleParamSuccess() {


### PR DESCRIPTION
- 작업 내용
  - Purchase Controller 테스트 작성
    - 구매 생성, 구매 취소 EP
  - Member Controller 테스트 작성
    - 멤버 조회, 멤버 구매 내역 조회 EP
  - Ticketing Controller 테스트 작성
    - 티켓팅 전체 조회, 부분 조회 EP
  - TestHelper createMember 오버로딩 추가 (email, roleEnum param)
  - Member, Purchase Controller EP에서 mockEmail > SecurityContextHelper.getEmailInToken()으로 수정